### PR TITLE
Implementation change to `tests/compare_buffer_functions.cpp`

### DIFF
--- a/tests/compare_buffer_functions.cpp
+++ b/tests/compare_buffer_functions.cpp
@@ -165,8 +165,8 @@ void evaluate_memfn(Class3Fn test_memfn, Class3Fn true_memfn, void* dst, void* s
 
     /* Now we compare the contents of both sets of buffers: the behavior of both
      * given functions is expected to be identical on each. */
-    EXPECT_EQ(memcmp(test_dst, true_dst, kMaxBufferSize), 0);
-    EXPECT_EQ(memcmp(test_src, true_src, kMaxBufferSize), 0);
+    EXPECT_EQ(memcmp(test_dst, true_dst, n), 0);
+    EXPECT_EQ(memcmp(test_src, true_src, n), 0);
 
     /* Release global buffers */
     buffers_lock.unlock();

--- a/tests/test_memmove.cpp
+++ b/tests/test_memmove.cpp
@@ -8,7 +8,7 @@
 
 TEST(memmove, Basic) {
         char s1[] = {'a', 'a', 'a', 'a', 'a', 's', 's', 's', 's', 's', 's', 'd', 'd', 'd', 'd', 'd', 'd', 'd', 'd', 'd', 'd', 'd'};
-        char s2[] = {'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x'};
+        char s2[] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v'};
         char s3[] = ":)";
 
        evaluate_memfn(_memmove, memmove, s1, s2, 20);
@@ -20,7 +20,7 @@ TEST(memmove, Basic) {
 
 TEST(memmove, Overlapping) {
         char s1[] = {'a', 'a', 'a', 'a', 'a', 's', 's', 's', 's', 's', 's', 'd', 'd', 'd', 'd', 'd', 'd', 'd', 'd', 'd', 'd', 'd'};
-        char s2[] = {'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x'};
+        char s2[] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v'};
 
        evaluate_memfn(_memmove, memmove, s1 + 0, s1 + 9, 20);
        evaluate_memfn(_memmove, memmove, s2 + 8, s2 + 0, 10);


### PR DESCRIPTION
As-is, `compare_buffer_functions.cpp` will fail if there are differences between the reference and test arrays up to some constant. We only care if there are differences up to a length of `n`. 